### PR TITLE
Field converter feature

### DIFF
--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -68,8 +68,10 @@ public class MethodCallRefactoring extends Refactoring {
 				// And then also add it to compilation unit itself
 				addFieldToCompilationUnit(pCompilationUnit, fieldDeclartionToAdd);
 				
+				// TODO: Create issue! Import is not added properly - x.addImport(Clazz) works fine though..!
 				pCompilationUnit.addImport(targetType, false, false);
 				
+				// TODO: Create issue sorting imports: Imports get duplicated..
 //				List<ImportDeclaration> importsToSort = new ArrayList<>(pCompilationUnit.getImports());
 //				pCompilationUnit.setImports(new NodeList<>());
 //				importsToSort.add(new ImportDeclaration(JavaParser.parseName(targetType), false, false));

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -23,7 +23,7 @@ import code.cafebabe.refactoring.action.Action;
 
 public class MethodCallRefactoring extends Refactoring {
 
-	private boolean trustImportStatements = true;
+	private boolean trustImportStatements = false;
 	private final Action action;
 
 	MethodCallRefactoring(final String pTargetType, final Action pAction, final String pReplacement) {

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -1,0 +1,67 @@
+package code.cafebabe.refactoring;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.google.common.collect.Lists;
+
+import code.cafebabe.refactoring.action.Action;
+
+public class MethodCallRefactoring extends Refactoring {
+
+	private boolean trustImportStatements = true;
+	private final Action action;
+
+	MethodCallRefactoring(final String pTargetType, final Action pAction, final String pReplacement) {
+		super(pTargetType, pReplacement);
+		action = pAction;
+	}
+
+	@Override
+	public CompilationUnit apply(final CompilationUnit pCompilationUnit, final TypeSolver pTypeSolver) {
+		if (trustImportStatements && !doImportsContainTargetType(pCompilationUnit, targetType)) {
+			return pCompilationUnit;
+		}
+
+		final Set<FieldDeclaration> matchingFieldDeclarationsForTargetType = resolveFieldDeclarations(pCompilationUnit,
+				targetType);
+		final Iterator<FieldDeclaration> matchingFieldDeclarationsForReplacementTypeIterator = resolveFieldDeclarations(
+				pCompilationUnit, replacement).iterator();
+		final Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType = matchingFieldDeclarationsForReplacementTypeIterator
+				.hasNext() ? Optional.of(matchingFieldDeclarationsForReplacementTypeIterator.next()) : Optional.empty();
+		// debugMatchingFields(matchingFieldDeclarations);
+
+		final List<MethodDeclaration> methodsToProcess = Navigator.findAllNodesOfGivenClass(pCompilationUnit,
+				MethodDeclaration.class);
+		methodsToProcess.forEach(m -> {
+			// Process every method in class from bottom to up
+			final List<Node> nodesToProcess = Lists.reverse(m.findFirst(BlockStmt.class).get().getChildNodes()).stream()
+					.filter(child -> action.isApplyable(child, targetType, pTypeSolver)).collect(Collectors.toList());
+
+			action.consume(nodesToProcess, matchingFieldDeclarationsForReplacementType);
+		});
+		action.consumeFieldDeclarations(matchingFieldDeclarationsForTargetType);
+		action.consumeImports(pCompilationUnit.getImports(), targetType);
+
+		return pCompilationUnit;
+	}
+
+	private void debugMatchingFields(final Set<FieldDeclaration> matchingFieldDeclarations) {
+		System.out.println("Matching FieldDeclarations: " + matchingFieldDeclarations);
+	}
+
+}

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -4,11 +4,11 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.CallableDeclaration;
@@ -70,7 +70,10 @@ public class MethodCallRefactoring extends Refactoring {
 
 				// TODO: Create issue! Import is not added properly -
 				// x.addImport(Clazz) works fine though..!
-				pCompilationUnit.addImport(targetType, false, false);
+				if (pCompilationUnit.getImports().stream().map(ImportDeclaration::getNameAsString)
+						.filter(importDec -> importDec.equals(targetType)).count() <= 0) {
+					pCompilationUnit.addImport(targetType, false, false);
+				}
 
 				// TODO: Create issue sorting imports: Imports get duplicated..
 				// List<ImportDeclaration> importsToSort = new
@@ -135,7 +138,8 @@ public class MethodCallRefactoring extends Refactoring {
 		String newFieldName = "javaRefactoringToolCreatedField";
 		final Set<String> desiredFieldNames = ((FieldConverterAction) action).getDesiredFieldNames();
 		// Process actions desired new field names and exclude the ones from the
-		// list, which are already declared in type - otherwise create with new random UUID!
+		// list, which are already declared in type - otherwise create with new
+		// random UUID!
 		if (classDeclaration.isPresent() && !desiredFieldNames.isEmpty()) {
 			final ClassOrInterfaceDeclaration classDec = classDeclaration.get();
 			classDec.getFields().stream().flatMap(f -> f.getVariables().stream())

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -43,7 +43,6 @@ public class MethodCallRefactoring extends Refactoring {
 				pCompilationUnit, replacement).iterator();
 		final Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType = matchingFieldDeclarationsForReplacementTypeIterator
 				.hasNext() ? Optional.of(matchingFieldDeclarationsForReplacementTypeIterator.next()) : Optional.empty();
-		// debugMatchingFields(matchingFieldDeclarations);
 
 		final List<MethodDeclaration> methodsToProcess = Navigator.findAllNodesOfGivenClass(pCompilationUnit,
 				MethodDeclaration.class);
@@ -58,10 +57,6 @@ public class MethodCallRefactoring extends Refactoring {
 		action.consumeImports(pCompilationUnit.getImports(), targetType);
 
 		return pCompilationUnit;
-	}
-
-	private void debugMatchingFields(final Set<FieldDeclaration> matchingFieldDeclarations) {
-		System.out.println("Matching FieldDeclarations: " + matchingFieldDeclarations);
 	}
 
 }

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -68,8 +68,10 @@ public class MethodCallRefactoring extends Refactoring {
 				// And then also add it to compilation unit itself
 				addFieldToCompilationUnit(pCompilationUnit, fieldDeclartionToAdd);
 				
+				// TODO: Create issue! Import is not added properly - x.addImport(Clazz) works fine though..!
 				pCompilationUnit.addImport(targetType, false, false);
 				
+				// TODO: Create issue sorting imports: Imports get duplicated..
 //				List<ImportDeclaration> importsToSort = new ArrayList<>(pCompilationUnit.getImports());
 //				pCompilationUnit.setImports(new NodeList<>());
 //				importsToSort.add(new ImportDeclaration(JavaParser.parseName(targetType), false, false));
@@ -110,6 +112,8 @@ public class MethodCallRefactoring extends Refactoring {
 				f.getMembers().addBefore(pFieldDeclartionToAdd, firstCallableDeclaration.get());
 			} else {
 				// Else (fallback) add as first member
+				// TODO: Create issue: When new member is added as first one
+				// intendation is not properly - as last one works though..
 				f.getMembers().addBefore(pFieldDeclartionToAdd, f.getMember(0));
 			}
 			

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -1,15 +1,26 @@
 package code.cafebabe.refactoring;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import code.cafebabe.refactoring.action.Action;
@@ -32,22 +43,88 @@ public class MethodCallRefactoring extends Refactoring {
 
 		final Set<FieldDeclaration> matchingFieldDeclarationsForTargetType = resolveFieldDeclarations(pCompilationUnit,
 				targetType);
+
 		final Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType = resolveFieldDeclarations(
 				pCompilationUnit, replacement);
 
 		final List<MethodDeclaration> methodsToProcess = pCompilationUnit.findAll(MethodDeclaration.class);
 
+		// Process each method individually
 		methodsToProcess.forEach(m -> {
-			// Process every method in class from bottom to up
 			final List<Node> nodesToProcess = m.findFirst(BlockStmt.class).get().findAll(MethodCallExpr.class).stream()
 					.filter(child -> action.isApplyable(child, targetType, pTypeSolver)).collect(Collectors.toList());
 
-			action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType, matchingFieldDeclarationsForReplacementType);
+			if (matchingFieldDeclarationsForTargetType.isEmpty() && !nodesToProcess.isEmpty()) {
+				// Since we want to convert method calls to field access (but
+				// any field of desired type is present in processed type)
+				// manually add one!
+				final FieldDeclaration fieldDeclartionToAdd = new FieldDeclaration(
+						EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL), createVariableDeclaration(nodesToProcess));
+
+				// Add field to list of 'retrieved' fields of desired type from
+				// processed file
+				matchingFieldDeclarationsForTargetType.add(fieldDeclartionToAdd);
+
+				// And then also add it to compilation unit itself
+				addFieldToCompilationUnit(pCompilationUnit, fieldDeclartionToAdd);
+				
+				pCompilationUnit.addImport(targetType, false, false);
+				
+//				List<ImportDeclaration> importsToSort = new ArrayList<>(pCompilationUnit.getImports());
+//				pCompilationUnit.setImports(new NodeList<>());
+//				importsToSort.add(new ImportDeclaration(JavaParser.parseName(targetType), false, false));
+				
+//				importsToSort.sort((i1, i2) -> i1.getNameAsString().compareTo(i2.getNameAsString()));
+//				pCompilationUnit.setImports(new NodeList<>(importsToSort));
+
+				// Let action consume retrieved nodes and do it's job
+				action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType,
+						matchingFieldDeclarationsForReplacementType);
+			}
 		});
 		action.consumeFieldDeclarations(matchingFieldDeclarationsForTargetType);
 		action.consumeImports(pCompilationUnit.getImports(), targetType);
 
 		return pCompilationUnit;
+	}
+
+	/**
+	 * Adds a given field declaration as first member before any
+	 * CallableDeclaration (eg ConstructorDeclaration or MethodDeclaration)
+	 * 
+	 * @param pCompilationUnit
+	 *            The compilation unit to add the field to
+	 * @param pFieldDeclartionToAdd
+	 *            The field declaration to add to the compilation unit
+	 * @param nodesToProcess
+	 */
+	private void addFieldToCompilationUnit(final CompilationUnit pCompilationUnit,
+			final FieldDeclaration pFieldDeclartionToAdd) {
+		final Optional<ClassOrInterfaceDeclaration> classDeclaration = pCompilationUnit
+				.findFirst(ClassOrInterfaceDeclaration.class);
+		classDeclaration.ifPresent(f -> {
+			Optional<CallableDeclaration> firstCallableDeclaration = f.findFirst(CallableDeclaration.class);
+
+			if (firstCallableDeclaration.isPresent()) {
+				// If any callable declaration is present - add before
+				f.getMembers().addBefore(pFieldDeclartionToAdd, firstCallableDeclaration.get());
+			} else {
+				// Else (fallback) add as first member
+				f.getMembers().addBefore(pFieldDeclartionToAdd, f.getMember(0));
+			}
+			
+		});
+	}
+
+	private VariableDeclarator createVariableDeclaration(final List<Node> nodesToProcess) {
+		// Create variable/ field initializer expression out of target MethodCallExpr which shall be replaced
+		return new VariableDeclarator(convertTargetTypeToType(), "logger",
+				(MethodCallExpr) nodesToProcess.get(0).clone());
+	}
+
+	private ClassOrInterfaceType convertTargetTypeToType() {
+		return JavaParser
+				.parseClassOrInterfaceType(targetType.substring(targetType.lastIndexOf('.') + 1, targetType.length()));
 	}
 
 }

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -1,8 +1,6 @@
 package code.cafebabe.refactoring;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -12,12 +10,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.resolution.MethodUsage;
-import com.github.javaparser.symbolsolver.javaparser.Navigator;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.google.common.collect.Lists;
 
 import code.cafebabe.refactoring.action.Action;
 
@@ -39,19 +32,17 @@ public class MethodCallRefactoring extends Refactoring {
 
 		final Set<FieldDeclaration> matchingFieldDeclarationsForTargetType = resolveFieldDeclarations(pCompilationUnit,
 				targetType);
-		final Iterator<FieldDeclaration> matchingFieldDeclarationsForReplacementTypeIterator = resolveFieldDeclarations(
-				pCompilationUnit, replacement).iterator();
-		final Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType = matchingFieldDeclarationsForReplacementTypeIterator
-				.hasNext() ? Optional.of(matchingFieldDeclarationsForReplacementTypeIterator.next()) : Optional.empty();
+		final Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType = resolveFieldDeclarations(
+				pCompilationUnit, replacement);
 
 		final List<MethodDeclaration> methodsToProcess = pCompilationUnit.findAll(MethodDeclaration.class);
 
 		methodsToProcess.forEach(m -> {
 			// Process every method in class from bottom to up
-			final List<Node> nodesToProcess = Lists.reverse(m.findFirst(BlockStmt.class).get().getChildNodes()).stream()
+			final List<Node> nodesToProcess = m.findFirst(BlockStmt.class).get().findAll(MethodCallExpr.class).stream()
 					.filter(child -> action.isApplyable(child, targetType, pTypeSolver)).collect(Collectors.toList());
 
-			action.consume(nodesToProcess, matchingFieldDeclarationsForReplacementType);
+			action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType, matchingFieldDeclarationsForReplacementType);
 		});
 		action.consumeFieldDeclarations(matchingFieldDeclarationsForTargetType);
 		action.consumeImports(pCompilationUnit.getImports(), targetType);

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -44,8 +44,8 @@ public class MethodCallRefactoring extends Refactoring {
 		final Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType = matchingFieldDeclarationsForReplacementTypeIterator
 				.hasNext() ? Optional.of(matchingFieldDeclarationsForReplacementTypeIterator.next()) : Optional.empty();
 
-		final List<MethodDeclaration> methodsToProcess = Navigator.findAllNodesOfGivenClass(pCompilationUnit,
-				MethodDeclaration.class);
+		final List<MethodDeclaration> methodsToProcess = pCompilationUnit.findAll(MethodDeclaration.class);
+
 		methodsToProcess.forEach(m -> {
 			// Process every method in class from bottom to up
 			final List<Node> nodesToProcess = Lists.reverse(m.findFirst(BlockStmt.class).get().getChildNodes()).stream()

--- a/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodCallRefactoring.java
@@ -1,6 +1,5 @@
 package code.cafebabe.refactoring;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -9,10 +8,8 @@ import java.util.stream.Collectors;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -59,7 +56,8 @@ public class MethodCallRefactoring extends Refactoring {
 				// any field of desired type is present in processed type)
 				// manually add one!
 				final FieldDeclaration fieldDeclartionToAdd = new FieldDeclaration(
-						EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL), createVariableDeclaration(nodesToProcess));
+						EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL),
+						createVariableDeclaration(nodesToProcess));
 
 				// Add field to list of 'retrieved' fields of desired type from
 				// processed file
@@ -67,22 +65,28 @@ public class MethodCallRefactoring extends Refactoring {
 
 				// And then also add it to compilation unit itself
 				addFieldToCompilationUnit(pCompilationUnit, fieldDeclartionToAdd);
-				
-				// TODO: Create issue! Import is not added properly - x.addImport(Clazz) works fine though..!
-				pCompilationUnit.addImport(targetType, false, false);
-				
-				// TODO: Create issue sorting imports: Imports get duplicated..
-//				List<ImportDeclaration> importsToSort = new ArrayList<>(pCompilationUnit.getImports());
-//				pCompilationUnit.setImports(new NodeList<>());
-//				importsToSort.add(new ImportDeclaration(JavaParser.parseName(targetType), false, false));
-				
-//				importsToSort.sort((i1, i2) -> i1.getNameAsString().compareTo(i2.getNameAsString()));
-//				pCompilationUnit.setImports(new NodeList<>(importsToSort));
 
-				// Let action consume retrieved nodes and do it's job
-				action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType,
-						matchingFieldDeclarationsForReplacementType);
+				// TODO: Create issue! Import is not added properly -
+				// x.addImport(Clazz) works fine though..!
+				pCompilationUnit.addImport(targetType, false, false);
+
+				// TODO: Create issue sorting imports: Imports get duplicated..
+				// List<ImportDeclaration> importsToSort = new
+				// ArrayList<>(pCompilationUnit.getImports());
+				// pCompilationUnit.setImports(new NodeList<>());
+				// importsToSort.add(new
+				// ImportDeclaration(JavaParser.parseName(targetType), false,
+				// false));
+
+				// importsToSort.sort((i1, i2) ->
+				// i1.getNameAsString().compareTo(i2.getNameAsString()));
+				// pCompilationUnit.setImports(new NodeList<>(importsToSort));
+
 			}
+
+			// Let action consume retrieved nodes and do it's job
+			action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType,
+					matchingFieldDeclarationsForReplacementType);
 		});
 		action.consumeFieldDeclarations(matchingFieldDeclarationsForTargetType);
 		action.consumeImports(pCompilationUnit.getImports(), targetType);
@@ -116,12 +120,13 @@ public class MethodCallRefactoring extends Refactoring {
 				// intendation is not properly - as last one works though..
 				f.getMembers().addBefore(pFieldDeclartionToAdd, f.getMember(0));
 			}
-			
+
 		});
 	}
 
 	private VariableDeclarator createVariableDeclaration(final List<Node> nodesToProcess) {
-		// Create variable/ field initializer expression out of target MethodCallExpr which shall be replaced
+		// Create variable/ field initializer expression out of target
+		// MethodCallExpr which shall be replaced
 		return new VariableDeclarator(convertTargetTypeToType(), "logger",
 				(MethodCallExpr) nodesToProcess.get(0).clone());
 	}

--- a/src/main/java/code/cafebabe/refactoring/MethodDeclarationRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodDeclarationRefactoring.java
@@ -21,12 +21,12 @@ import com.google.common.collect.Lists;
 
 import code.cafebabe.refactoring.action.Action;
 
-public class MethodCallRefactoring extends Refactoring {
+public class MethodDeclarationRefactoring extends Refactoring {
 
 	private boolean trustImportStatements = true;
 	private final Action action;
 
-	MethodCallRefactoring(final String pTargetType, final Action pAction, final String pReplacement) {
+	MethodDeclarationRefactoring(final String pTargetType, final Action pAction, final String pReplacement) {
 		super(pTargetType, pReplacement);
 		action = pAction;
 	}

--- a/src/main/java/code/cafebabe/refactoring/MethodDeclarationRefactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/MethodDeclarationRefactoring.java
@@ -39,10 +39,8 @@ public class MethodDeclarationRefactoring extends Refactoring {
 
 		final Set<FieldDeclaration> matchingFieldDeclarationsForTargetType = resolveFieldDeclarations(pCompilationUnit,
 				targetType);
-		final Iterator<FieldDeclaration> matchingFieldDeclarationsForReplacementTypeIterator = resolveFieldDeclarations(
-				pCompilationUnit, replacement).iterator();
-		final Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType = matchingFieldDeclarationsForReplacementTypeIterator
-				.hasNext() ? Optional.of(matchingFieldDeclarationsForReplacementTypeIterator.next()) : Optional.empty();
+		final Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType = resolveFieldDeclarations(
+				pCompilationUnit, replacement);
 		// debugMatchingFields(matchingFieldDeclarations);
 
 		final List<MethodDeclaration> methodsToProcess = Navigator.findAllNodesOfGivenClass(pCompilationUnit,
@@ -52,7 +50,7 @@ public class MethodDeclarationRefactoring extends Refactoring {
 			final List<Node> nodesToProcess = Lists.reverse(m.findFirst(BlockStmt.class).get().getChildNodes()).stream()
 					.filter(child -> action.isApplyable(child, targetType, pTypeSolver)).collect(Collectors.toList());
 
-			action.consume(nodesToProcess, matchingFieldDeclarationsForReplacementType);
+			action.consume(nodesToProcess, matchingFieldDeclarationsForTargetType, matchingFieldDeclarationsForReplacementType);
 		});
 		action.consumeFieldDeclarations(matchingFieldDeclarationsForTargetType);
 		action.consumeImports(pCompilationUnit.getImports(), targetType);

--- a/src/main/java/code/cafebabe/refactoring/Refactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/Refactoring.java
@@ -91,9 +91,6 @@ public abstract class Refactoring {
 				.map(ImportDeclaration::getNameAsString).filter(pTargetTypeToLookFor::equals).count();
 	}
 
-	public abstract <T extends Node> boolean isApplyable(final T pNode, final String pTargetType,
-			TypeSolver pMySolver);
-
 	public abstract CompilationUnit apply(final CompilationUnit pCompilataionUnit, final TypeSolver pTypeSolver);
 
 }

--- a/src/main/java/code/cafebabe/refactoring/Refactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/Refactoring.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;

--- a/src/main/java/code/cafebabe/refactoring/Refactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/Refactoring.java
@@ -46,7 +46,7 @@ public abstract class Refactoring {
 			if (target == null) {
 				throw new IllegalStateException("No target to look for! Call \"andTarget\" first!");
 			}
-			return new MethodCallRefactoring(target, action, replacement);
+			return new MethodDeclarationRefactoring(target, action, replacement);
 		}
 
 	}

--- a/src/main/java/code/cafebabe/refactoring/Refactoring.java
+++ b/src/main/java/code/cafebabe/refactoring/Refactoring.java
@@ -14,6 +14,7 @@ import com.github.javaparser.symbolsolver.javaparser.Navigator;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import code.cafebabe.refactoring.action.Action;
+import code.cafebabe.refactoring.action.FieldConverterAction;
 
 public abstract class Refactoring {
 
@@ -44,6 +45,9 @@ public abstract class Refactoring {
 		public Refactoring build() {
 			if (target == null) {
 				throw new IllegalStateException("No target to look for! Call \"andTarget\" first!");
+			}
+			if (action instanceof FieldConverterAction) {
+				return new MethodCallRefactoring(target, action, replacement);
 			}
 			return new MethodDeclarationRefactoring(target, action, replacement);
 		}

--- a/src/main/java/code/cafebabe/refactoring/action/Action.java
+++ b/src/main/java/code/cafebabe/refactoring/action/Action.java
@@ -9,13 +9,17 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public abstract class Action {
 
-    public abstract void consume(final List<Node> pNodesToProcess, Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType);
+	public abstract <T extends Node> boolean isApplyable(final T pNode, final String pTargetType, TypeSolver pMySolver);
 
-    public abstract void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations);
+	public abstract void consume(final List<Node> pNodesToProcess,
+			Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType);
 
-    public abstract void consumeImports(final List<ImportDeclaration> imports, final String pTargetType);
+	public abstract void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations);
+
+	public abstract void consumeImports(final List<ImportDeclaration> imports, final String pTargetType);
 
 }

--- a/src/main/java/code/cafebabe/refactoring/action/Action.java
+++ b/src/main/java/code/cafebabe/refactoring/action/Action.java
@@ -1,13 +1,10 @@
 package code.cafebabe.refactoring.action;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
@@ -16,7 +13,8 @@ public abstract class Action {
 	public abstract <T extends Node> boolean isApplyable(final T pNode, final String pTargetType, TypeSolver pMySolver);
 
 	public abstract void consume(final List<Node> pNodesToProcess,
-			Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType);
+			Set<FieldDeclaration> matchingFieldDeclarationsForTargetType,
+			Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType);
 
 	public abstract void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations);
 

--- a/src/main/java/code/cafebabe/refactoring/action/ExtendingAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/ExtendingAction.java
@@ -15,6 +15,9 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class ExtendingAction extends Action {
 
@@ -86,13 +89,64 @@ public final class ExtendingAction extends Action {
     @Override
     public void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations) {
         // TODO Auto-generated method stub
-
     }
 
     @Override
     public void consumeImports(final List<ImportDeclaration> pImports, final String pTargetType) {
         // TODO Auto-generated method stub
-
     }
+    
+    @Override
+	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pTypeSolver) {
+		if (pNode instanceof ExpressionStmt) {
+			return isApplyable((ExpressionStmt) pNode, pTargetType, pTypeSolver);
+		}
+		return false;
+	}
+	
+	private boolean isApplyable(final ExpressionStmt pExpression, final String pTargetType,
+			final TypeSolver pTypeSolver) {
+		final Optional<MethodCallExpr> m = pExpression.findFirst(MethodCallExpr.class);
+		if (m.isPresent() && m.get().isMethodCallExpr()) {
+			final MethodCallExpr methodCall = m.get();
+
+			final MethodUsage resolvedMethodCall = JavaParserFacade.get(pTypeSolver).solveMethodAsUsage(methodCall);
+			return isDeclaringTypeTargetType(resolvedMethodCall, pTargetType)
+					|| isReturnTypeTargetType(resolvedMethodCall, pTargetType);
+
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if the declaring type of this MethodCall is the same as the target
+	 * type to look for.
+	 * 
+	 * @param pResolvedMethodCall
+	 *            The resolved method call
+	 * @param pTargetType
+	 *            The target type to look for
+	 * @return true, if the declaring type for this method call is the same as
+	 *         the target type to look for otherwise false
+	 */
+	private boolean isDeclaringTypeTargetType(final MethodUsage pResolvedMethodCall, final String pTargetType) {
+		return pResolvedMethodCall.declaringType().getQualifiedName().equals(pTargetType);
+	}
+
+	/**
+	 * Checks if the return type of this MethodCall is the same as the target
+	 * type to look for.
+	 * 
+	 * @param pResolvedMethodCall
+	 *            The resolved method call
+	 * @param pTargetType
+	 *            The target type to look for
+	 * @return true, if the return type for this method call is the same as the
+	 *         target type to look for otherwise false
+	 */
+	private boolean isReturnTypeTargetType(final MethodUsage pResolvedMethodCall, final String pTargetType) {
+		return pResolvedMethodCall.returnType().isReferenceType()
+				&& pResolvedMethodCall.returnType().describe().equals(pTargetType);
+	}
 
 }

--- a/src/main/java/code/cafebabe/refactoring/action/ExtendingAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/ExtendingAction.java
@@ -21,89 +21,95 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class ExtendingAction extends Action {
 
-    @Override
-    public void consume(final List<Node> pNodesToProcess, final Optional<FieldDeclaration> p) {
-        // Workaround to add multiple children from same node in LexicalPreserving printer => Save former parent
-        Optional<BlockStmt> parent = Optional.empty();
-        for (final Node n : pNodesToProcess) {
-            parent = parent.isPresent() ? parent : n.findParent(BlockStmt.class);
-            parent.ifPresent(surroundingBlock -> {
-                final NodeList<Statement> newStatements = new NodeList<>();
-                Iterator<Node> iterator = surroundingBlock.getChildNodes().iterator();
-                while (iterator.hasNext()) {
-                    Statement next = (Statement) iterator.next();
-                    Statement child = copy(next);
-                    newStatements.add(child);
-                    if (pNodesToProcess.contains(child)) {
-                        process(p, newStatements, child);
-                    }
-                }
-                surroundingBlock.replace(new BlockStmt(newStatements));
-            });
-        }
-    }
+	@Override
+	public void consume(final List<Node> pNodesToProcess, Set<FieldDeclaration> pMatchingFieldDeclarationsForTargetType,
+			final Set<FieldDeclaration> pmatchingFieldDeclarationsForReplacementType) {
+		// Workaround to add multiple children from same node in
+		// LexicalPreserving printer => Save former parent
+		Optional<BlockStmt> parent = Optional.empty();
+		Optional<FieldDeclaration> matchingReplacementType = !pmatchingFieldDeclarationsForReplacementType.isEmpty() ? Optional.of(pmatchingFieldDeclarationsForReplacementType.iterator().next()) : Optional.empty();
+		
+		for (final Node n : pNodesToProcess) {
+			parent = parent.isPresent() ? parent : n.findParent(BlockStmt.class);
+			parent.ifPresent(surroundingBlock -> {
+				final NodeList<Statement> newStatements = new NodeList<>();
+				Iterator<Node> iterator = surroundingBlock.getChildNodes().iterator();
+				while (iterator.hasNext()) {
+					Statement next = (Statement) iterator.next();
+					Statement child = copy(next);
+					newStatements.add(child);
+					if (pNodesToProcess.contains(child)) {
+						process(matchingReplacementType, newStatements, child);
+					}
+				}
+				surroundingBlock.replace(new BlockStmt(newStatements));
+			});
+		}
+	}
 
-    private void process(final Optional<FieldDeclaration> p, final NodeList<Statement> newStatements, Statement child) {
-        final Optional<MethodCallExpr> firstContainedMethodCall = child.findFirst(MethodCallExpr.class);
-        if (firstContainedMethodCall.isPresent()) {
-            
-            final MethodCallExpr methodCallExpr = firstContainedMethodCall.get().clone();
-            Expression expression = methodCallExpr.getScope().get();
-            if (expression.isNameExpr()) {
-                expression.asNameExpr().setName(p.get().findFirst(VariableDeclarator.class).get().getNameAsString());
-            } else if (expression.isFieldAccessExpr()) {
-                expression.asFieldAccessExpr().getName().setIdentifier(p.get().findFirst(VariableDeclarator.class).get().getNameAsString());
-            }
-            newStatements.add(new ExpressionStmt(methodCallExpr));
-        }
-    }
+	private void process(final Optional<FieldDeclaration> p, final NodeList<Statement> newStatements, Statement child) {
+		final Optional<MethodCallExpr> firstContainedMethodCall = child.findFirst(MethodCallExpr.class);
+		if (firstContainedMethodCall.isPresent()) {
 
-    private Statement copy(final Statement next) {
-        if (next.isExpressionStmt()) {
-            ExpressionStmt expressionStmt = new ExpressionStmt(next.asExpressionStmt().getExpression());
-            next.getRange().ifPresent(r -> {
-                expressionStmt.setRange(r);
-            });
-            return expressionStmt;
-        }
-        return next.clone();
-    }
+			final MethodCallExpr methodCallExpr = firstContainedMethodCall.get().clone();
+			Expression expression = methodCallExpr.getScope().get();
+			if (expression.isNameExpr()) {
+				expression.asNameExpr().setName(p.get().findFirst(VariableDeclarator.class).get().getNameAsString());
+			} else if (expression.isFieldAccessExpr()) {
+				expression.asFieldAccessExpr().getName()
+						.setIdentifier(p.get().findFirst(VariableDeclarator.class).get().getNameAsString());
+			}
+			newStatements.add(new ExpressionStmt(methodCallExpr));
+		}
+	}
 
-    public void consumeOld(final List<Node> pNodesToProcess) {
-        // Workaround to add multiple children from same node in LexicalPreserving printer => Save former parent
-        Optional<BlockStmt> parent = Optional.empty();
-        for (final Node n : pNodesToProcess) {
-            parent = parent.isPresent() ? parent : n.findParent(BlockStmt.class);
-            parent.ifPresent(surroundingBlock -> {
-                final Optional<MethodCallExpr> firstContainedMethodCall = n.findFirst(MethodCallExpr.class);
-                if (firstContainedMethodCall.isPresent()) {
-                    final MethodCallExpr methodCallExpr = new MethodCallExpr();
-                    methodCallExpr.setName(firstContainedMethodCall.get().getName());
-                    methodCallExpr.setArguments(firstContainedMethodCall.get().getArguments());
-                    surroundingBlock.addStatement(methodCallExpr);
-                }
-            });
-        }
-    }
+	private Statement copy(final Statement next) {
+		if (next.isExpressionStmt()) {
+			ExpressionStmt expressionStmt = new ExpressionStmt(next.asExpressionStmt().getExpression());
+			next.getRange().ifPresent(r -> {
+				expressionStmt.setRange(r);
+			});
+			return expressionStmt;
+		}
+		return next.clone();
+	}
 
-    @Override
-    public void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations) {
-        // TODO Auto-generated method stub
-    }
+	public void consumeOld(final List<Node> pNodesToProcess) {
+		// Workaround to add multiple children from same node in
+		// LexicalPreserving printer => Save former parent
+		Optional<BlockStmt> parent = Optional.empty();
+		for (final Node n : pNodesToProcess) {
+			parent = parent.isPresent() ? parent : n.findParent(BlockStmt.class);
+			parent.ifPresent(surroundingBlock -> {
+				final Optional<MethodCallExpr> firstContainedMethodCall = n.findFirst(MethodCallExpr.class);
+				if (firstContainedMethodCall.isPresent()) {
+					final MethodCallExpr methodCallExpr = new MethodCallExpr();
+					methodCallExpr.setName(firstContainedMethodCall.get().getName());
+					methodCallExpr.setArguments(firstContainedMethodCall.get().getArguments());
+					surroundingBlock.addStatement(methodCallExpr);
+				}
+			});
+		}
+	}
 
-    @Override
-    public void consumeImports(final List<ImportDeclaration> pImports, final String pTargetType) {
-        // TODO Auto-generated method stub
-    }
-    
-    @Override
+	@Override
+	public void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void consumeImports(final List<ImportDeclaration> pImports, final String pTargetType) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
 	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pTypeSolver) {
 		if (pNode instanceof ExpressionStmt) {
 			return isApplyable((ExpressionStmt) pNode, pTargetType, pTypeSolver);
 		}
 		return false;
 	}
-	
+
 	private boolean isApplyable(final ExpressionStmt pExpression, final String pTargetType,
 			final TypeSolver pTypeSolver) {
 		final Optional<MethodCallExpr> m = pExpression.findFirst(MethodCallExpr.class);

--- a/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class FieldConverterAction extends Action {
 
@@ -24,6 +25,11 @@ public final class FieldConverterAction extends Action {
 
 	@Override
 	public void consumeImports(final List<ImportDeclaration> pImports, String pTargetType) {
+	}
+
+	@Override
+	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pMySolver) {
+		return false;
 	}
 
 }

--- a/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
@@ -3,6 +3,7 @@ package code.cafebabe.refactoring.action;
 import java.util.List;
 import java.util.Set;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -16,10 +17,16 @@ public final class FieldConverterAction extends Action {
 	@Override
 	public void consume(List<Node> pNodesToProcess, Set<FieldDeclaration> matchingFieldDeclarationsForTargetType,
 			Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType) {
-		if (pNodesToProcess.isEmpty()) {
-			return;
+		
+		if (!pNodesToProcess.isEmpty() && !matchingFieldDeclarationsForTargetType.isEmpty()) {
+			final FieldDeclaration matchingField = matchingFieldDeclarationsForTargetType.iterator().next();
+			
+			for (Node nodeToProcess : pNodesToProcess) {
+				MethodCallExpr convertedNode = (MethodCallExpr) nodeToProcess;
+				convertedNode.replace(JavaParser.parseExpression(matchingField.getVariable(0).getNameAsString()));
+			}
 		}
-		System.out.println(pNodesToProcess);
+		
 	}
 
 	@Override

--- a/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
@@ -1,5 +1,6 @@
 package code.cafebabe.refactoring.action;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -13,6 +14,12 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class FieldConverterAction extends Action {
+
+	private final Set<String> desiredFieldNames = new LinkedHashSet<>();
+	
+	public FieldConverterAction(final List<String> pDesiredFieldNames) {
+		desiredFieldNames.addAll(pDesiredFieldNames);
+	}
 
 	@Override
 	public void consume(List<Node> pNodesToProcess, Set<FieldDeclaration> matchingFieldDeclarationsForTargetType,
@@ -60,4 +67,7 @@ public final class FieldConverterAction extends Action {
 				&& pResolvedMethodCall.returnType().describe().equals(pTargetType);
 	}
 
+	public Set<String> getDesiredFieldNames() {
+		return new LinkedHashSet<>(desiredFieldNames);
+	}
 }

--- a/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;

--- a/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/FieldConverterAction.java
@@ -1,19 +1,24 @@
 package code.cafebabe.refactoring.action;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class FieldConverterAction extends Action {
 
 	@Override
-	public void consume(List<Node> pNodesToProcess,
-			Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType) {
+	public void consume(List<Node> pNodesToProcess, Set<FieldDeclaration> matchingFieldDeclarationsForTargetType,
+			Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType) {
+		if (pNodesToProcess.isEmpty()) {
+			return;
+		}
 		System.out.println(pNodesToProcess);
 	}
 
@@ -27,8 +32,25 @@ public final class FieldConverterAction extends Action {
 	}
 
 	@Override
-	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pMySolver) {
-		return false;
+	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pTypeSolver) {
+		return pNode instanceof MethodCallExpr && isReturnTypeTargetType(
+				JavaParserFacade.get(pTypeSolver).solveMethodAsUsage((MethodCallExpr) pNode), pTargetType);
+	}
+
+	/**
+	 * Checks if the return type of this MethodCall is the same as the target
+	 * type to look for.
+	 * 
+	 * @param pResolvedMethodCall
+	 *            The resolved method call
+	 * @param pTargetType
+	 *            The target type to look for
+	 * @return true, if the return type for this method call is the same as the
+	 *         target type to look for otherwise false
+	 */
+	private boolean isReturnTypeTargetType(final MethodUsage pResolvedMethodCall, final String pTargetType) {
+		return pResolvedMethodCall.returnType().isReferenceType()
+				&& pResolvedMethodCall.returnType().describe().equals(pTargetType);
 	}
 
 }

--- a/src/main/java/code/cafebabe/refactoring/action/RemovingAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/RemovingAction.java
@@ -16,36 +16,38 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class RemovingAction extends Action {
 
-    @Override
-    public void consume(final List<Node> pNodesToProcess, Optional<FieldDeclaration> matchingFieldDeclarationsForReplacementType) {
-        // Workaround to remove multiple children from same node in LexicalPreserving printer => Save former parent
-        Optional<Node> parent = Optional.empty();
-        for (final Node node : pNodesToProcess) {
-            parent = parent.isPresent() ? parent : node.getParentNode();
-            parent.ifPresent(n -> n.remove(node));
-        }
-    }
+	@Override
+	public void consume(final List<Node> pNodesToProcess, Set<FieldDeclaration> matchingFieldDeclarationsForTargetType,
+			Set<FieldDeclaration> matchingFieldDeclarationsForReplacementType) {
+		// Workaround to remove multiple children from same node in
+		// LexicalPreserving printer => Save former parent
+		Optional<Node> parent = Optional.empty();
+		for (final Node node : pNodesToProcess) {
+			parent = parent.isPresent() ? parent : node.getParentNode();
+			parent.ifPresent(n -> n.remove(node));
+		}
+	}
 
-    @Override
-    public void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations) {
-        pFieldDeclarations.forEach(FieldDeclaration::remove);
-    }
+	@Override
+	public void consumeFieldDeclarations(final Set<FieldDeclaration> pFieldDeclarations) {
+		pFieldDeclarations.forEach(FieldDeclaration::remove);
+	}
 
-    @Override
-    public void consumeImports(final List<ImportDeclaration> pImports, final String pTargetType) {
-        Set<ImportDeclaration> importsToRemove = pImports.stream().filter(i -> i != null).filter(i -> pTargetType.equals(i.getNameAsString()))
-                .collect(Collectors.toSet());
-        importsToRemove.forEach(ImportDeclaration::remove);
-    }
-    
-    @Override
+	@Override
+	public void consumeImports(final List<ImportDeclaration> pImports, final String pTargetType) {
+		Set<ImportDeclaration> importsToRemove = pImports.stream().filter(i -> i != null)
+				.filter(i -> pTargetType.equals(i.getNameAsString())).collect(Collectors.toSet());
+		importsToRemove.forEach(ImportDeclaration::remove);
+	}
+
+	@Override
 	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pTypeSolver) {
 		if (pNode instanceof ExpressionStmt) {
 			return isApplyable((ExpressionStmt) pNode, pTargetType, pTypeSolver);
 		}
 		return false;
 	}
-	
+
 	private boolean isApplyable(final ExpressionStmt pExpression, final String pTargetType,
 			final TypeSolver pTypeSolver) {
 		final Optional<MethodCallExpr> m = pExpression.findFirst(MethodCallExpr.class);

--- a/src/main/java/code/cafebabe/refactoring/action/RemovingAction.java
+++ b/src/main/java/code/cafebabe/refactoring/action/RemovingAction.java
@@ -8,6 +8,11 @@ import java.util.stream.Collectors;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 public final class RemovingAction extends Action {
 
@@ -32,5 +37,58 @@ public final class RemovingAction extends Action {
                 .collect(Collectors.toSet());
         importsToRemove.forEach(ImportDeclaration::remove);
     }
+    
+    @Override
+	public <T extends Node> boolean isApplyable(T pNode, String pTargetType, TypeSolver pTypeSolver) {
+		if (pNode instanceof ExpressionStmt) {
+			return isApplyable((ExpressionStmt) pNode, pTargetType, pTypeSolver);
+		}
+		return false;
+	}
+	
+	private boolean isApplyable(final ExpressionStmt pExpression, final String pTargetType,
+			final TypeSolver pTypeSolver) {
+		final Optional<MethodCallExpr> m = pExpression.findFirst(MethodCallExpr.class);
+		if (m.isPresent() && m.get().isMethodCallExpr()) {
+			final MethodCallExpr methodCall = m.get();
+
+			final MethodUsage resolvedMethodCall = JavaParserFacade.get(pTypeSolver).solveMethodAsUsage(methodCall);
+			return isDeclaringTypeTargetType(resolvedMethodCall, pTargetType)
+					|| isReturnTypeTargetType(resolvedMethodCall, pTargetType);
+
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if the declaring type of this MethodCall is the same as the target
+	 * type to look for.
+	 * 
+	 * @param pResolvedMethodCall
+	 *            The resolved method call
+	 * @param pTargetType
+	 *            The target type to look for
+	 * @return true, if the declaring type for this method call is the same as
+	 *         the target type to look for otherwise false
+	 */
+	private boolean isDeclaringTypeTargetType(final MethodUsage pResolvedMethodCall, final String pTargetType) {
+		return pResolvedMethodCall.declaringType().getQualifiedName().equals(pTargetType);
+	}
+
+	/**
+	 * Checks if the return type of this MethodCall is the same as the target
+	 * type to look for.
+	 * 
+	 * @param pResolvedMethodCall
+	 *            The resolved method call
+	 * @param pTargetType
+	 *            The target type to look for
+	 * @return true, if the return type for this method call is the same as the
+	 *         target type to look for otherwise false
+	 */
+	private boolean isReturnTypeTargetType(final MethodUsage pResolvedMethodCall, final String pTargetType) {
+		return pResolvedMethodCall.returnType().isReferenceType()
+				&& pResolvedMethodCall.returnType().describe().equals(pTargetType);
+	}
 
 }

--- a/src/test/java/code/cafebabe/refactoring/MethodCallRefactoringTest.java
+++ b/src/test/java/code/cafebabe/refactoring/MethodCallRefactoringTest.java
@@ -36,7 +36,6 @@ import code.cafebabe.refactoring.action.RemovingAction;
 import code.cafebabe.refactoring.factory.CompilationUnitFactory;
 import code.cafebabe.refactoring.factory.TypeSolverFactory;
 import code.cafebabe.refactoring.util.CompilationUnitWriter;
-import complexClass.custom.Logger;
 
 @RunWith(JUnitPlatform.class)
 public class MethodCallRefactoringTest {
@@ -51,7 +50,7 @@ public class MethodCallRefactoringTest {
     public void removingActionGivesExpectedResult(final String pTestFolderName, final String pTestClassName, final String pTestClassTargetName) {
 
         // Given
-        final Refactoring change = MethodCallRefactoring.RefactoringBuilder.of(new RemovingAction()).andTarget("complexClass.custom.Logger").build();
+        final Refactoring change = MethodDeclarationRefactoring.RefactoringBuilder.of(new RemovingAction()).andTarget("complexClass.custom.Logger").build();
         final File testBase = new File(TEST_RESOURCES_BASE, pTestFolderName);
         final File target = new File(TEST_RESOURCES_TARGETS, pTestFolderName + pTestClassTargetName);
 
@@ -89,7 +88,7 @@ public class MethodCallRefactoringTest {
     public void removingActionGivesExpectedResult2() {
 
         // Given
-        final Refactoring change = MethodCallRefactoring.RefactoringBuilder.of(new RemovingAction()).andTarget("complexClass.custom.Logger").build();
+        final Refactoring change = Refactoring.RefactoringBuilder.of(new RemovingAction()).andTarget("complexClass.custom.Logger").build();
         final String testFolderMain = "complexClass/";
         final String testFileName = "ComplexClass.java";
         final String targetFileName = "ComplexClassAfterRemoval.java";
@@ -140,7 +139,7 @@ public class MethodCallRefactoringTest {
     public void extendingActionGivesExpectedResult() {
 
         // Given
-        final Refactoring change = MethodCallRefactoring.RefactoringBuilder.of(new ExtendingAction()).andTarget("complexClass.custom.Logger").andReplacement("org.slf4j.Logger").build();
+        final Refactoring change = Refactoring.RefactoringBuilder.of(new ExtendingAction()).andTarget("complexClass.custom.Logger").andReplacement("org.slf4j.Logger").build();
         final String testFolderMain = "complexClass/";
         final String testFileName = "ComplexClass.java";
         final String testFileTargetName = "ComplexClassAfterExtension.java";

--- a/src/test/java/code/cafebabe/refactoring/MethodDeclarationRefactoringTest.java
+++ b/src/test/java/code/cafebabe/refactoring/MethodDeclarationRefactoringTest.java
@@ -38,7 +38,7 @@ import code.cafebabe.refactoring.factory.TypeSolverFactory;
 import code.cafebabe.refactoring.util.CompilationUnitWriter;
 
 @RunWith(JUnitPlatform.class)
-public class MethodCallRefactoringTest {
+public class MethodDeclarationRefactoringTest {
 
     private static final File TEST_RESOURCES_BASE = new File("src/test/resources/");
     private static final File TEST_RESOURCES_TARGETS = new File(TEST_RESOURCES_BASE, "targets");

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -129,23 +129,59 @@ public class SingleThreadedProcessorTest {
 		final String targetFileName = "MethodCallClassTargetDefault.java";
 		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
 		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
-		
+
 		final CodeBase codeBase = CodeBase.CodeBaseBuilder.fromRoots(testBase).addJarRoot("lib/slf4j-api-1.7.25.jar")
 				.build();
-		
+
 		final Set<Change> changes = new SingleThreadedProcessor().process(codeBase, change);
-		
+
 		final Optional<String> transformed = changes.stream()
 				.filter(c -> testFileName.equals(c.getOriginal().getSourceFile().getName())).map(Change::getTransformed)
 				.map(LexicalPreservingPrinter::print).findFirst();
-		
+
 		if (!transformed.isPresent()) {
 			fail("Missing transformed file: \"" + targetFileName + "\"!");
 		}
-		
+
 		assertEquals(
 				LexicalPreservingPrinter
-				.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
+						.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
+				transformed.get());
+	}
+
+	/**
+	 * This test case assures, that an existing field of 'target type' in
+	 * processed class is reused instead of having a new one created
+	 * 
+	 * @throws FileNotFoundException
+	 */
+	@Test
+	public void methodCallInstanceIsConvertedToExistingField() throws FileNotFoundException {
+		final List<String> desiredFieldNames = asList("myLogger");
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction(desiredFieldNames))
+				.andTarget("introduceField.custom.Logger").build();
+		final String testFolderName = "reuseField/";
+		final String testFileName = "MethodCallClass.java";
+		final String targetFileName = "MethodCallClassTarget.java";
+		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
+		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
+
+		final CodeBase codeBase = CodeBase.CodeBaseBuilder.fromRoots(testBase).addJarRoot("lib/slf4j-api-1.7.25.jar")
+				.build();
+
+		final Set<Change> changes = new SingleThreadedProcessor().process(codeBase, change);
+
+		final Optional<String> transformed = changes.stream()
+				.filter(c -> testFileName.equals(c.getOriginal().getSourceFile().getName())).map(Change::getTransformed)
+				.map(LexicalPreservingPrinter::print).findFirst();
+
+		if (!transformed.isPresent()) {
+			fail("Missing transformed file: \"" + targetFileName + "\"!");
+		}
+
+		assertEquals(
+				LexicalPreservingPrinter
+						.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
 				transformed.get());
 	}
 

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -16,7 +16,7 @@ import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinte
 
 import code.cafebabe.refactoring.Change;
 import code.cafebabe.refactoring.CodeBase;
-import code.cafebabe.refactoring.MethodCallRefactoring;
+import code.cafebabe.refactoring.MethodDeclarationRefactoring;
 import code.cafebabe.refactoring.Refactoring;
 import code.cafebabe.refactoring.action.RemovingAction;
 import code.cafebabe.refactoring.factory.CompilationUnitFactory;
@@ -30,7 +30,7 @@ public class SingleThreadedProcessorTest {
 
 	@Test
 	public void test() throws FileNotFoundException {
-		final Refactoring change = MethodCallRefactoring.RefactoringBuilder.of(new RemovingAction())
+		final Refactoring change = MethodDeclarationRefactoring.RefactoringBuilder.of(new RemovingAction())
 				.andTarget("complexClass.custom.Logger").build();
 		final String testFolderName = "complexClass/";
 		final String testFileName = "ComplexClass.java";

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -60,7 +60,7 @@ public class SingleThreadedProcessorTest {
 	@Test
 	public void methodCallInstanceIsConvertedToField() throws FileNotFoundException {
 		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction())
-				.andTarget("complexClass.custom.Logger").build();
+				.andTarget("introduceField.custom.Logger").build();
 		final String testFolderName = "introduceField/";
 		final String testFileName = "MethodCallClass.java";
 		final String targetFileName = "MethodCallClassTarget.java";

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -86,4 +86,33 @@ public class SingleThreadedProcessorTest {
 				transformed.get());
 	}
 
+	@Test
+	public void methodCallInstanceIsConvertedToFieldWithDesiredName() throws FileNotFoundException {
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction())
+				.andTarget("introduceField.custom.Logger").build();
+		final String testFolderName = "introduceFieldExistingFieldWithSameName/";
+		final String testFileName = "MethodCallClass.java";
+		final String targetFileName = "MethodCallClassTarget.java";
+		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
+		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
+		
+		final CodeBase codeBase = CodeBase.CodeBaseBuilder.fromRoots(testBase).addJarRoot("lib/slf4j-api-1.7.25.jar")
+				.build();
+		
+		final Set<Change> changes = new SingleThreadedProcessor().process(codeBase, change);
+		
+		final Optional<String> transformed = changes.stream()
+				.filter(c -> testFileName.equals(c.getOriginal().getSourceFile().getName())).map(Change::getTransformed)
+				.map(LexicalPreservingPrinter::print).findFirst();
+		
+		if (!transformed.isPresent()) {
+			fail("Missing transformed file: \"" + targetFileName + "\"!");
+		}
+		
+		assertEquals(
+				LexicalPreservingPrinter
+				.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
+				transformed.get());
+	}
+
 }

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -20,7 +20,6 @@ import code.cafebabe.refactoring.MethodDeclarationRefactoring;
 import code.cafebabe.refactoring.Refactoring;
 import code.cafebabe.refactoring.action.RemovingAction;
 import code.cafebabe.refactoring.factory.CompilationUnitFactory;
-import complexClass.custom.Logger;
 
 @RunWith(JUnitPlatform.class)
 public class SingleThreadedProcessorTest {

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -18,6 +18,7 @@ import code.cafebabe.refactoring.Change;
 import code.cafebabe.refactoring.CodeBase;
 import code.cafebabe.refactoring.MethodDeclarationRefactoring;
 import code.cafebabe.refactoring.Refactoring;
+import code.cafebabe.refactoring.action.FieldConverterAction;
 import code.cafebabe.refactoring.action.RemovingAction;
 import code.cafebabe.refactoring.factory.CompilationUnitFactory;
 
@@ -58,7 +59,7 @@ public class SingleThreadedProcessorTest {
 
 	@Test
 	public void methodCallInstanceIsConvertedToField() throws FileNotFoundException {
-		final Refactoring change = Refactoring.RefactoringBuilder.of(new RemovingAction())
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction())
 				.andTarget("complexClass.custom.Logger").build();
 		final String testFolderName = "introduceField/";
 		final String testFileName = "MethodCallClass.java";

--- a/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
+++ b/src/test/java/code/cafebabe/refactoring/processor/SingleThreadedProcessorTest.java
@@ -1,10 +1,12 @@
 package code.cafebabe.refactoring.processor;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -59,40 +61,72 @@ public class SingleThreadedProcessorTest {
 
 	@Test
 	public void methodCallInstanceIsConvertedToField() throws FileNotFoundException {
-		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction())
+		final List<String> desiredFieldNames = asList("logger", "myLogger");
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction(desiredFieldNames))
 				.andTarget("introduceField.custom.Logger").build();
 		final String testFolderName = "introduceField/";
 		final String testFileName = "MethodCallClass.java";
 		final String targetFileName = "MethodCallClassTarget.java";
 		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
 		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
-		
+
 		final CodeBase codeBase = CodeBase.CodeBaseBuilder.fromRoots(testBase).addJarRoot("lib/slf4j-api-1.7.25.jar")
 				.build();
-		
+
 		final Set<Change> changes = new SingleThreadedProcessor().process(codeBase, change);
-		
+
 		final Optional<String> transformed = changes.stream()
 				.filter(c -> testFileName.equals(c.getOriginal().getSourceFile().getName())).map(Change::getTransformed)
 				.map(LexicalPreservingPrinter::print).findFirst();
-		
+
 		if (!transformed.isPresent()) {
 			fail("Missing transformed file: \"" + targetFileName + "\"!");
 		}
-		
+
 		assertEquals(
 				LexicalPreservingPrinter
-				.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
+						.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
 				transformed.get());
 	}
 
 	@Test
 	public void methodCallInstanceIsConvertedToFieldWithDesiredName() throws FileNotFoundException {
-		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction())
+		final List<String> desiredFieldNames = asList("logger", "myLogger");
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction(desiredFieldNames))
 				.andTarget("introduceField.custom.Logger").build();
 		final String testFolderName = "introduceFieldExistingFieldWithSameName/";
 		final String testFileName = "MethodCallClass.java";
 		final String targetFileName = "MethodCallClassTarget.java";
+		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
+		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
+
+		final CodeBase codeBase = CodeBase.CodeBaseBuilder.fromRoots(testBase).addJarRoot("lib/slf4j-api-1.7.25.jar")
+				.build();
+
+		final Set<Change> changes = new SingleThreadedProcessor().process(codeBase, change);
+
+		final Optional<String> transformed = changes.stream()
+				.filter(c -> testFileName.equals(c.getOriginal().getSourceFile().getName())).map(Change::getTransformed)
+				.map(LexicalPreservingPrinter::print).findFirst();
+
+		if (!transformed.isPresent()) {
+			fail("Missing transformed file: \"" + targetFileName + "\"!");
+		}
+
+		assertEquals(
+				LexicalPreservingPrinter
+						.print(CompilationUnitFactory.createPreservingCompilationUnit(target).getCompilationUnit()),
+				transformed.get());
+	}
+
+	@Test
+	public void methodCallInstanceIsConvertedToFieldWithDefaultName() throws FileNotFoundException {
+		final List<String> desiredFieldNames = asList("logger");
+		final Refactoring change = Refactoring.RefactoringBuilder.of(new FieldConverterAction(desiredFieldNames))
+				.andTarget("introduceField.custom.Logger").build();
+		final String testFolderName = "introduceFieldExistingFieldWithSameName/";
+		final String testFileName = "MethodCallClass.java";
+		final String targetFileName = "MethodCallClassTargetDefault.java";
 		final File testBase = new File(TEST_RESOURCES_BASE, testFolderName);
 		final File target = new File(TEST_RESOURCES_TARGETS, testFolderName + targetFileName);
 		

--- a/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/MethodCallClass.java
+++ b/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/MethodCallClass.java
@@ -1,0 +1,15 @@
+import java.io.FileNotFoundException;
+
+import introduceField.custom.MessageLogger;
+
+public class MethodCallClass {
+
+	public void print() {
+		try {
+			throw new FileNotFoundException();
+		} catch (FileNotFoundException e) {
+			MessageLogger.instance().logAsInternalException(e);
+		}
+	}
+	
+}

--- a/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/MethodCallClass.java
+++ b/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/MethodCallClass.java
@@ -3,6 +3,8 @@ import java.io.FileNotFoundException;
 import introduceField.custom.MessageLogger;
 
 public class MethodCallClass {
+	
+	private static final StringBuilder logger = new StringBuilder();
 
 	public void print() {
 		try {

--- a/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/custom/Logger.java
+++ b/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/custom/Logger.java
@@ -1,0 +1,377 @@
+package introduceField.custom;
+
+import org.slf4j.Marker;
+
+public class Logger implements org.slf4j.Logger {
+	
+	public void logAsInternalException(Throwable e) {
+		// Individual test method
+	}
+
+    @Override
+    public void debug(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public String getName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void info(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void trace(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/custom/MessageLogger.java
+++ b/src/test/resources/introduceFieldExistingFieldWithSameName/introduceField/custom/MessageLogger.java
@@ -1,0 +1,9 @@
+package introduceField.custom;
+
+public class MessageLogger {
+
+    public static Logger instance() {
+        return new Logger();
+    }
+
+}

--- a/src/test/resources/reuseField/introduceField/MethodCallClass.java
+++ b/src/test/resources/reuseField/introduceField/MethodCallClass.java
@@ -1,0 +1,18 @@
+import java.io.FileNotFoundException;
+
+import introduceField.custom.Logger;
+import introduceField.custom.MessageLogger;
+
+public class MethodCallClass {
+	
+	private static final Logger logger = MessageLogger.instance();
+
+	public void print() {
+		try {
+			throw new FileNotFoundException();
+		} catch (FileNotFoundException e) {
+			MessageLogger.instance().logAsInternalException(e);
+		}
+	}
+	
+}

--- a/src/test/resources/reuseField/introduceField/custom/Logger.java
+++ b/src/test/resources/reuseField/introduceField/custom/Logger.java
@@ -1,0 +1,377 @@
+package introduceField.custom;
+
+import org.slf4j.Marker;
+
+public class Logger implements org.slf4j.Logger {
+	
+	public void logAsInternalException(Throwable e) {
+		// Individual test method
+	}
+
+    @Override
+    public void debug(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public String getName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void info(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void trace(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object... arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Throwable arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(String arg0, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object... arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Throwable arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker arg0, String arg1, Object arg2, Object arg3) {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/src/test/resources/reuseField/introduceField/custom/MessageLogger.java
+++ b/src/test/resources/reuseField/introduceField/custom/MessageLogger.java
@@ -1,0 +1,9 @@
+package introduceField.custom;
+
+public class MessageLogger {
+
+    public static Logger instance() {
+        return new Logger();
+    }
+
+}

--- a/src/test/resources/targets/introduceField/MethodCallClassTarget.java
+++ b/src/test/resources/targets/introduceField/MethodCallClassTarget.java
@@ -5,7 +5,7 @@ import introduceField.custom.MessageLogger;
 
 public class MethodCallClass {
 	
-	private static Logger logger = MessageLogger.instance();
+	private static final Logger logger = MessageLogger.instance();
 
 	public void print() {
 		try {

--- a/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTarget.java
+++ b/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTarget.java
@@ -1,0 +1,18 @@
+import java.io.FileNotFoundException;
+
+import introduceField.custom.Logger;
+import introduceField.custom.MessageLogger;
+
+public class MethodCallClass {
+	
+	private static final Logger myLogger = MessageLogger.instance();
+
+	public void print() {
+		try {
+			throw new FileNotFoundException();
+		} catch (FileNotFoundException e) {
+			myLogger.logAsInternalException(e);
+		}
+	}
+	
+}

--- a/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTarget.java
+++ b/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTarget.java
@@ -5,6 +5,8 @@ import introduceField.custom.MessageLogger;
 
 public class MethodCallClass {
 	
+	private static final StringBuilder logger = new StringBuilder();
+	
 	private static final Logger myLogger = MessageLogger.instance();
 
 	public void print() {

--- a/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTargetDefault.java
+++ b/src/test/resources/targets/introduceFieldExistingFieldWithSameName/MethodCallClassTargetDefault.java
@@ -1,0 +1,20 @@
+import java.io.FileNotFoundException;
+
+import introduceField.custom.Logger;
+import introduceField.custom.MessageLogger;
+
+public class MethodCallClass {
+	
+	private static final StringBuilder logger = new StringBuilder();
+	
+	private static final Logger JavaRefactoringToolCreatedField = MessageLogger.instance();
+
+	public void print() {
+		try {
+			throw new FileNotFoundException();
+		} catch (FileNotFoundException e) {
+			JavaRefactoringToolCreatedField.logAsInternalException(e);
+		}
+	}
+	
+}

--- a/src/test/resources/targets/reuseField/MethodCallClassTarget.java
+++ b/src/test/resources/targets/reuseField/MethodCallClassTarget.java
@@ -1,0 +1,18 @@
+import java.io.FileNotFoundException;
+
+import introduceField.custom.Logger;
+import introduceField.custom.MessageLogger;
+
+public class MethodCallClass {
+	
+	private static final Logger logger = MessageLogger.instance();
+
+	public void print() {
+		try {
+			throw new FileNotFoundException();
+		} catch (FileNotFoundException e) {
+			logger.logAsInternalException(e);
+		}
+	}
+	
+}


### PR DESCRIPTION
Added new 'FieldConverterFeature' where method calls which return specific target type are replaced by field access. If field of desired target type exists it is reused. If it's missing it's tried to add one with a desired name. If the desired name would cause compilation issues a default name is used as fallback